### PR TITLE
Set default CA

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -270,7 +270,7 @@ variable "publicly_accessible" {
 variable "ca_cert_identifier" {
   description = "The identifier of the CA certificate for the DB instance"
   type        = string
-  default     = null
+  default     = "rds-ca-rsa4096-g1"
 }
 
 variable "monitoring_interval" {


### PR DESCRIPTION
Set default CA to one expiring in 2121.

Uses a certificate authority with RSA 4096 private key algorithm and SHA384 signing algorithm. This CA supports automatic server certificate rotation.